### PR TITLE
Minor tweaks to mp3 hasher and benching

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -236,11 +236,8 @@ fn mp3_hash(file_path: &PathBuf) -> Result<Checksum, CheckError> {
     let mut hashers: SmallVec<[Blake2b; 2]> = SmallVec::from_buf(Default::default());
     let mut channels = 0;
 
-    for result in decoder {
-        let mut frame = match result {
-            Ok(fr) => fr,
-            _ => continue,
-        };
+    // Skip errored-out frames, as simplemad tries to parse metadata as audio too
+    for mut frame in decoder.filter_map(|f| f.ok()) {
         channels = match frame.mode {
             MadMode::SingleChannel => 1,
             _ => 2,

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -175,19 +175,23 @@ fn get_filetype(fpath: &PathBuf) -> Result<Filetype, CheckError> {
     }
 }
 
+#[inline]
 unsafe fn as_u8_slice<T: Copy>(buf: &[T]) -> &[u8] {
     ::std::slice::from_raw_parts(buf.as_ptr() as *const u8, buf.len() * ::std::mem::size_of::<T>())
 }
 
+#[inline]
 fn i32_as_u8_slice(buf: &[i32]) -> &[u8] {
     unsafe { as_u8_slice(buf) }
 }
 
+#[inline]
 unsafe fn as_i32_slice<T: Copy>(buf: &mut [T]) -> &mut [i32] {
     debug_assert_eq!(::std::mem::size_of::<T>() % 4, 0);
     ::std::slice::from_raw_parts_mut(buf.as_ptr() as *mut i32, buf.len() * (::std::mem::size_of::<T>() / 4))
 }
 
+#[inline]
 fn madfixed_as_i32_slice(buf: &mut [::simplemad::MadFixed32]) -> &mut [i32] {
     unsafe { as_i32_slice(buf) }
 }

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -203,7 +203,7 @@ fn flac_hash(file_path: &PathBuf) -> Result<Checksum, CheckError> {
     // We use a SmallVec to allocate our hashers (up to 8, because if the audio
     // file has more than 8 channels then God save us) on the stack for faster
     // access. Excess hashers will spill over to heap causing slowdown.
-    let mut hashers = SmallVec::<[Blake2b; 8]>::from(vec![Blake2b::new(); channels]);
+    let mut hashers: SmallVec<[Blake2b; 8]> = ::std::iter::repeat(Blake2b::new()).take(channels).collect();
 
     while let Some(block) = frame_reader.read_next_or_eof(block_buffer)? {
         let duration = block.duration() as usize;
@@ -253,7 +253,7 @@ fn mp3_hash(file_path: &PathBuf) -> Result<Checksum, CheckError> {
     // We use a SmallVec to allocate our hashers (at most 2 because that's the
     // limit of the MP3 format) on the stack for faster access. Excess hashers
     // will spill over to heap causing slowdown.
-    let mut hashers = SmallVec::<[Blake2b; 2]>::from(vec![Blake2b::new(); channels]);
+    let mut hashers: SmallVec<[Blake2b; 2]> = ::std::iter::repeat(Blake2b::new()).take(channels).collect();
 
     for ch in 0..channels {
         let mut frame_buffer = madfixed_as_i32_slice(&mut initial.samples[ch]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,13 +21,30 @@ pub fn check_songs() {
     ];
 
     for song in songs {
-        let start = time::PreciseTime::now();
-        let check = match checksum::hash_audio(&song) {
-            Err(why) => panic!("{}", why),
-            Ok(check) => check,
-        };
-        let end = time::PreciseTime::now();
-        println!("{}", check);
-        println!("---- {:?} took: {:?}", song, start.to(end));
+        let mut sample_times = [0i64; 32];
+        let mut hashes: Vec<checksum::Checksum> = Vec::with_capacity(sample_times.len());
+
+        println!("---- song: {:?}", song);
+        for sample_time in &mut sample_times {
+            let start = time::PreciseTime::now();
+            let check = match checksum::hash_audio(&song) {
+                Err(why) => panic!("{}", why),
+                Ok(check) => check,
+            };
+            let end = time::PreciseTime::now();
+            *sample_time = start.to(end).num_nanoseconds().unwrap();
+            hashes.push(check);
+        }
+        let min = sample_times.iter().min().unwrap();
+        let max = sample_times.iter().max().unwrap();
+        let avg: i64 = sample_times.iter().sum::<i64>() / sample_times.len() as i64;
+        let stddev = (sample_times.iter().map(|v| (v - avg) as f64).map(|v| v * v).sum::<f64>() / (sample_times.len() - 1) as f64).sqrt() as i64;
+        hashes.dedup();
+        //println!("took: {:?}", sample_times);
+        println!("hash: {:?}", hashes);
+        if hashes.len() != 1 {
+            panic!("Bug! Inconsistent hash calculation.")
+        }
+        println!("---- min: {}; avg: {}; max: {}; stddev: {}", min, avg, max, stddev);
     }
 }


### PR DESCRIPTION
I've changed mp3 hashing to be slightly faster, but with the downside that it no longer computes the same hash as before.

Also it now runs 32 hashings on the same file to more accurately measure time.